### PR TITLE
Control status dot visibility

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,10 @@ import { moduleConfig } from './modules/moduleConfig';
 function App() {
   const [currentModule, setCurrentModule] = useState('MicroSchedule');
   const [viewMode, setViewMode] = useState('individual'); // 'individual' or 'overview'
+  
+  // Global state for dot visibility - both default to false (turned off)
+  const [showFutureDot, setShowFutureDot] = useState(false);
+  const [showCurrentDot, setShowCurrentDot] = useState(false);
 
   const modules = Object.keys(moduleConfig).map(moduleId => ({
     id: moduleId,
@@ -53,6 +57,40 @@ function App() {
               </button>
             </div>
           </div>
+          
+          {/* Dot Visibility Controls */}
+          <div className="dot-controls">
+            <h4 className="dot-controls-title">Status Dots</h4>
+            <div className="dot-control-item">
+              <label className="dot-control-label">
+                <input
+                  type="checkbox"
+                  checked={showFutureDot}
+                  onChange={(e) => setShowFutureDot(e.target.checked)}
+                  className="dot-control-checkbox"
+                />
+                <span className="dot-control-text">
+                  <span className="dot-indicator future-dot"></span>
+                  Future Status (Green)
+                </span>
+              </label>
+            </div>
+            <div className="dot-control-item">
+              <label className="dot-control-label">
+                <input
+                  type="checkbox"
+                  checked={showCurrentDot}
+                  onChange={(e) => setShowCurrentDot(e.target.checked)}
+                  className="dot-control-checkbox"
+                />
+                <span className="dot-control-text">
+                  <span className="dot-indicator current-dot"></span>
+                  Current Status (Orange)
+                </span>
+              </label>
+            </div>
+          </div>
+          
           <div className="sidebar-content">
             {viewMode === 'individual' && (
               <div className="module-list">
@@ -79,7 +117,10 @@ function App() {
         {/* Main Content Area */}
         <div className="main-content">
           {viewMode === 'overview' ? (
-            <OverviewChart />
+            <OverviewChart 
+              showFutureDot={showFutureDot}
+              showCurrentDot={showCurrentDot}
+            />
           ) : (
             <>
               {moduleConfig[currentModule]?.type === 'pipeline' ? (
@@ -89,6 +130,8 @@ function App() {
                   moduleId={currentModule}
                   onNavigate={handleNavigate}
                   showNavigation={true}
+                  showFutureDot={showFutureDot}
+                  showCurrentDot={showCurrentDot}
                 />
               )}
             </>

--- a/src/ImpactEffortChart.css
+++ b/src/ImpactEffortChart.css
@@ -277,6 +277,73 @@
     background-color: #2563eb;
 }
 
+/* Dot Controls Section */
+.dot-controls {
+    padding: 16px;
+    border-bottom: 1px solid #e2e8f0;
+    background-color: #ffffff;
+}
+
+.dot-controls-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1e293b;
+    margin: 0 0 12px 0;
+}
+
+.dot-control-item {
+    margin-bottom: 8px;
+}
+
+.dot-control-item:last-child {
+    margin-bottom: 0;
+}
+
+.dot-control-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 6px 8px;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+}
+
+.dot-control-label:hover {
+    background-color: #f8fafc;
+}
+
+.dot-control-checkbox {
+    margin-right: 8px;
+    cursor: pointer;
+}
+
+.dot-control-text {
+    display: flex;
+    align-items: center;
+    font-size: 13px;
+    color: #475569;
+    font-weight: 500;
+}
+
+.dot-indicator {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-right: 8px;
+    display: inline-block;
+    border: 2px solid;
+}
+
+.dot-indicator.future-dot {
+    background-color: #22c55e;
+    border-color: #16a34a;
+}
+
+.dot-indicator.current-dot {
+    background-color: #f97316;
+    border-color: #ea580c;
+}
+
 .overview-info {
     padding: 16px;
     color: #6b7280;

--- a/src/modules/ImpactEffortModule.js
+++ b/src/modules/ImpactEffortModule.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import '../ImpactEffortChart.css';
 import { moduleConfig, chartConfig, getPlotDimensions } from './moduleConfig';
 
-const ImpactEffortModule = ({ moduleId, onNavigate, showNavigation = true }) => {
+const ImpactEffortModule = ({ moduleId, onNavigate, showNavigation = true, showFutureDot = false, showCurrentDot = false }) => {
     const [notes, setNotes] = useState('');
     const config = moduleConfig[moduleId];
 
@@ -181,40 +181,48 @@ const ImpactEffortModule = ({ moduleId, onNavigate, showNavigation = true }) => 
                     />
 
                     {/* Future Impact Point (Green) */}
-                    <circle
-                        cx={futureCoords.x}
-                        cy={futureCoords.y}
-                        r="12"
-                        fill="#22c55e"
-                        stroke="#16a34a"
-                        strokeWidth="2"
-                    />
-                    <text
-                        x={futureCoords.x}
-                        y={futureCoords.y + 5}
-                        textAnchor="middle"
-                        className="point-text"
-                    >
-                        F
-                    </text>
+                    {showFutureDot && (
+                        <>
+                            <circle
+                                cx={futureCoords.x}
+                                cy={futureCoords.y}
+                                r="12"
+                                fill="#22c55e"
+                                stroke="#16a34a"
+                                strokeWidth="2"
+                            />
+                            <text
+                                x={futureCoords.x}
+                                y={futureCoords.y + 5}
+                                textAnchor="middle"
+                                className="point-text"
+                            >
+                                F
+                            </text>
+                        </>
+                    )}
 
                     {/* Current Impact Point (Orange) */}
-                    <circle
-                        cx={currentCoords.x}
-                        cy={currentCoords.y}
-                        r="12"
-                        fill="#f97316"
-                        stroke="#ea580c"
-                        strokeWidth="2"
-                    />
-                    <text
-                        x={currentCoords.x}
-                        y={currentCoords.y + 5}
-                        textAnchor="middle"
-                        className="point-text"
-                    >
-                        C
-                    </text>
+                    {showCurrentDot && (
+                        <>
+                            <circle
+                                cx={currentCoords.x}
+                                cy={currentCoords.y}
+                                r="12"
+                                fill="#f97316"
+                                stroke="#ea580c"
+                                strokeWidth="2"
+                            />
+                            <text
+                                x={currentCoords.x}
+                                y={currentCoords.y + 5}
+                                textAnchor="middle"
+                                className="point-text"
+                            >
+                                C
+                            </text>
+                        </>
+                    )}
 
                     {/* Y-axis label */}
                     <text

--- a/src/modules/OverviewChart.js
+++ b/src/modules/OverviewChart.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import '../ImpactEffortChart.css';
 import { moduleConfig, chartConfig, getPlotDimensions } from './moduleConfig';
 
-const OverviewChart = () => {
+const OverviewChart = ({ showFutureDot = false, showCurrentDot = false }) => {
     const [visibleModules, setVisibleModules] = useState({});
     const [tooltip, setTooltip] = useState({ show: false, content: '', x: 0, y: 0 });
 
@@ -321,30 +321,34 @@ const OverviewChart = () => {
                                 />
 
                                 {/* Future Impact Point (Green) */}
-                                <circle
-                                    cx={futureCoords.x}
-                                    cy={futureCoords.y}
-                                    r="8"
-                                    fill="#22c55e"
-                                    stroke="#16a34a"
-                                    strokeWidth="2"
-                                    onMouseEnter={(e) => handleMouseEnter(e, module.name, 'Future Status')}
-                                    onMouseLeave={handleMouseLeave}
-                                    style={{ cursor: 'pointer' }}
-                                />
+                                {showFutureDot && (
+                                    <circle
+                                        cx={futureCoords.x}
+                                        cy={futureCoords.y}
+                                        r="8"
+                                        fill="#22c55e"
+                                        stroke="#16a34a"
+                                        strokeWidth="2"
+                                        onMouseEnter={(e) => handleMouseEnter(e, module.name, 'Future Status')}
+                                        onMouseLeave={handleMouseLeave}
+                                        style={{ cursor: 'pointer' }}
+                                    />
+                                )}
 
                                 {/* Current Impact Point (Orange) */}
-                                <circle
-                                    cx={currentCoords.x}
-                                    cy={currentCoords.y}
-                                    r="8"
-                                    fill="#f97316"
-                                    stroke="#ea580c"
-                                    strokeWidth="2"
-                                    onMouseEnter={(e) => handleMouseEnter(e, module.name, 'Current Status')}
-                                    onMouseLeave={handleMouseLeave}
-                                    style={{ cursor: 'pointer' }}
-                                />
+                                {showCurrentDot && (
+                                    <circle
+                                        cx={currentCoords.x}
+                                        cy={currentCoords.y}
+                                        r="8"
+                                        fill="#f97316"
+                                        stroke="#ea580c"
+                                        strokeWidth="2"
+                                        onMouseEnter={(e) => handleMouseEnter(e, module.name, 'Current Status')}
+                                        onMouseLeave={handleMouseLeave}
+                                        style={{ cursor: 'pointer' }}
+                                    />
+                                )}
                             </g>
                         );
                     })}


### PR DESCRIPTION
Add global toggle switches to control the visibility of future (green) and current (orange) status dots on Individual and Overview pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-df8d57e0-15d7-4e11-9624-37b6a3dc3ae6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df8d57e0-15d7-4e11-9624-37b6a3dc3ae6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>